### PR TITLE
feat(726): Hard

### DIFF
--- a/internal/Leetcode/726/726.go
+++ b/internal/Leetcode/726/726.go
@@ -1,0 +1,70 @@
+package _726
+
+import (
+	"sort"
+	"strconv"
+	"strings"
+)
+
+func countOfAtoms(formula string) string {
+	stack := make([]map[string]int, 0, len(formula)/2)
+	stack = append(stack, make(map[string]int))
+	n := len(formula)
+	i := 0
+
+	for i < n {
+		if formula[i] == '(' {
+			stack = append(stack, make(map[string]int))
+			i++
+		} else if formula[i] == ')' {
+			currMap := stack[len(stack)-1]
+			stack = stack[:len(stack)-1]
+			prevMap := stack[len(stack)-1]
+			i++
+			start := i
+			for i < n && formula[i] >= '0' && formula[i] <= '9' {
+				i++
+			}
+			count := 1
+			if start < i {
+				count, _ = strconv.Atoi(formula[start:i])
+			}
+			for el, num := range currMap {
+				prevMap[el] += num * count
+			}
+		} else {
+			start := i
+			i++
+			for i < n && formula[i] >= 'a' && formula[i] <= 'z' {
+				i++
+			}
+			element := formula[start:i]
+			start = i
+			for i < n && formula[i] >= '0' && formula[i] <= '9' {
+				i++
+			}
+			count := 1
+			if start < i {
+				count, _ = strconv.Atoi(formula[start:i])
+			}
+			stack[len(stack)-1][element] += count
+		}
+	}
+
+	countMap := stack[0]
+	elements := make([]string, 0, len(countMap))
+	for el := range countMap {
+		elements = append(elements, el)
+	}
+	sort.Strings(elements)
+
+	var result strings.Builder
+	for _, el := range elements {
+		result.WriteString(el)
+		if countMap[el] > 1 {
+			result.WriteString(strconv.Itoa(countMap[el]))
+		}
+	}
+
+	return result.String()
+}

--- a/internal/Leetcode/726/726_test.go
+++ b/internal/Leetcode/726/726_test.go
@@ -1,0 +1,52 @@
+package _726
+
+import (
+	"testing"
+)
+
+func Test_countOfAtoms(t *testing.T) {
+	type args struct {
+		formula string
+	}
+	tests := []struct {
+		name string
+		args args
+		want string
+	}{
+		{
+			name: "Test 1",
+			args: args{
+				formula: "H2O",
+			},
+			want: "H2O",
+		},
+		{
+			name: "Test 2",
+			args: args{
+				formula: "Mg(OH)2",
+			},
+			want: "H2MgO2",
+		},
+		{
+			name: "Test 3",
+			args: args{
+				formula: "K4(ON(SO3)2)2",
+			},
+			want: "K4N2O14S4",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := countOfAtoms(tt.args.formula); got != tt.want {
+				t.Errorf("countOfAtoms() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func Benchmark_countOfAtoms(b *testing.B) {
+	for i := 0; i < b.N; i++ {
+		countOfAtoms("K4(ON(SO3)2)2")
+	}
+}


### PR DESCRIPTION
Given a string formula representing a chemical formula, return the count of each atom.

The atomic element always starts with an uppercase character, then zero or more lowercase letters, representing the name.

One or more digits representing that element's count may follow if the count is greater than 1. If the count is 1, no digits will follow.

For example, "H2O" and "H2O2" are possible, but "H1O2" is impossible. Two formulas are concatenated together to produce another formula.

For example, "H2O2He3Mg4" is also a formula.
A formula placed in parentheses, and a count (optionally added) is also a formula.

For example, "(H2O2)" and "(H2O2)3" are formulas.
Return the count of all elements as a string in the following form: the first name (in sorted order), followed by its count (if that count is more than 1), followed by the second name (in sorted order), followed by its count (if that count is more than 1), and so on.

The test cases are generated so that all the values in the output fit in a 32-bit integer.

Example 1:

Input: formula = "H2O"
Output: "H2O"
Explanation: The count of elements are {'H': 2, 'O': 1}. Example 2:

Input: formula = "Mg(OH)2"
Output: "H2MgO2"
Explanation: The count of elements are {'H': 2, 'Mg': 1, 'O': 2}. Example 3:

Input: formula = "K4(ON(SO3)2)2"
Output: "K4N2O14S4"
Explanation: The count of elements are {'K': 4, 'N': 2, 'O': 14, 'S': 4}.

Constraints:

1 <= formula.length <= 1000
formula consists of English letters, digits, '(', and ')'. formula is always valid.