### PR TITLE
feat(2191): Medium

### DIFF
--- a/internal/Leetcode/2191/2191.go
+++ b/internal/Leetcode/2191/2191.go
@@ -1,0 +1,69 @@
+package _2191
+
+import (
+	"fmt"
+	"sort"
+)
+
+// Funkcja sortująca tablicę nums zgodnie z mapowanymi wartościami
+func sortJumbled(mapping []int, nums []int) []int {
+	// Tworzymy listę par (oryginalna liczba, zmapowana liczba)
+	type numPair struct {
+		original int
+		mapped   int
+	}
+
+	pairs := make([]numPair, len(nums))
+	for i, num := range nums {
+		pairs[i] = numPair{
+			original: num,
+			mapped:   mappingNum(num, mapping),
+		}
+	}
+
+	// Sortujemy pary najpierw po mapped, a następnie po oryginalnej wartości dla tiebreaker
+	sort.SliceStable(pairs, func(i, j int) bool {
+		if pairs[i].mapped == pairs[j].mapped {
+			return pairs[i].original == pairs[j].original
+		}
+		return pairs[i].mapped < pairs[j].mapped
+	})
+
+	// Tworzymy wynikową tablicę z posortowanymi oryginalnymi wartościami
+	result := make([]int, len(nums))
+	for i, pair := range pairs {
+		result[i] = pair.original
+	}
+
+	return result
+}
+
+// Funkcja mapująca liczbę zgodnie z podaną mapą
+func mappingNum(num int, mapping []int) int {
+	// Obsługa przypadku gdy num jest 0
+	if num == 0 {
+		return mapping[0]
+	}
+
+	result := 0
+	positionMultiplier := 1
+	for num > 0 {
+		// Pobieramy ostatnią cyfrę
+		digit := num % 10
+		// Przypisujemy przemapowaną cyfrę
+		mappedDigit := mapping[digit]
+		// Dodajemy przemapowaną cyfrę do wyniku, uwzględniając pozycję dziesiętną
+		result += mappedDigit * positionMultiplier
+		positionMultiplier *= 10
+		// Usuwamy ostatnią cyfrę
+		num /= 10
+	}
+	return result
+}
+
+func main() {
+	mapping := []int{9, 8, 7, 6, 5, 4, 3, 2, 1, 0}
+	nums := []int{990, 332, 981}
+	sortedNums := sortJumbled(mapping, nums)
+	fmt.Println(sortedNums) // Oczekiwany wynik: [332, 981, 990]
+}

--- a/internal/Leetcode/2191/2191_test.go
+++ b/internal/Leetcode/2191/2191_test.go
@@ -1,0 +1,57 @@
+package _2191
+
+import (
+	"reflect"
+	"testing"
+)
+
+func Test_sortJumbled(t *testing.T) {
+	type args struct {
+		mapping []int
+		nums    []int
+	}
+	tests := []struct {
+		name string
+		args args
+		want []int
+	}{
+		{
+			name: "Example 1",
+			args: args{
+				mapping: []int{8, 9, 4, 0, 2, 1, 3, 5, 7, 6},
+				nums:    []int{991, 338, 38},
+			},
+			want: []int{338, 38, 991},
+		},
+		{
+			name: "Example 2",
+			args: args{
+				mapping: []int{0, 1, 2, 3, 4, 5, 6, 7, 8, 9},
+				nums:    []int{789, 456, 123},
+			},
+			want: []int{123, 456, 789},
+		},
+		{
+			name: "Example 3",
+			args: args{
+				mapping: []int{9, 8, 7, 6, 5, 4, 3, 2, 1, 0},
+				nums:    []int{9, 99, 999, 9999, 999999999},
+			},
+			want: []int{9, 99, 999, 9999, 999999999},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := sortJumbled(tt.args.mapping, tt.args.nums); !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("sortJumbled() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func Benchmark_sortJumbled(b *testing.B) {
+	for i := 0; i < b.N; i++ {
+		sortJumbled([]int{8, 9, 4, 0, 2, 1, 3, 5, 7, 6}, []int{991, 338, 38})
+	}
+}


### PR DESCRIPTION
You are given a 0-indexed integer array mapping which represents the mapping rule of a shuffled decimal system. mapping[i] = j means digit i should be mapped to digit j in this system.

The mapped value of an integer is the new integer obtained by replacing each occurrence of digit i in the integer with mapping[i] for all 0 <= i <= 9.

You are also given another integer array nums. Return the array nums sorted in non-decreasing order based on the mapped values of its elements.

Notes:

Elements with the same mapped values should appear in the same relative order as in the input. The elements of nums should only be sorted based on their mapped values and not be replaced by them.

Example 1:

Input: mapping = [8,9,4,0,2,1,3,5,7,6], nums = [991,338,38] Output: [338,38,991]
Explanation:
Map the number 991 as follows:
1. mapping[9] = 6, so all occurrences of the digit 9 will become 6.
2. mapping[1] = 9, so all occurrences of the digit 1 will become 9. Therefore, the mapped value of 991 is 669.
338 maps to 007, or 7 after removing the leading zeros. 38 maps to 07, which is also 7 after removing leading zeros. Since 338 and 38 share the same mapped value, they should remain in the same relative order, so 338 comes before 38. Thus, the sorted array is [338,38,991].
Example 2:

Input: mapping = [0,1,2,3,4,5,6,7,8,9], nums = [789,456,123]
Output: [123,456,789]
Explanation: 789 maps to 789, 456 maps to 456, and 123 maps to 123. Thus, the sorted array is [123,456,789].

Constraints:

mapping.length == 10
0 <= mapping[i] <= 9
All the values of mapping[i] are unique.
1 <= nums.length <= 3 * 104
0 <= nums[i] < 109