### PR TITLE
feat(840): Medium

### DIFF
--- a/internal/Leetcode/840/840.go
+++ b/internal/Leetcode/840/840.go
@@ -1,0 +1,32 @@
+package _840
+
+import (
+	"strconv"
+	"strings"
+)
+
+func numMagicSquaresInside(grid [][]int) int {
+	ans := 0
+
+	for i := 0; i+2 < len(grid); i++ {
+		for j := 0; j+2 < len(grid[0]); j++ {
+			if grid[i][j]%2 == 0 && grid[i+1][j+1] == 5 {
+				if isMagic(grid, i, j) {
+					ans++
+				}
+			}
+		}
+	}
+
+	return ans
+}
+
+func isMagic(grid [][]int, i, j int) bool {
+	s := ""
+
+	for _, num := range []int{0, 1, 2, 5, 8, 7, 6, 3} {
+		s += strconv.Itoa(grid[i+num/3][j+num%3])
+	}
+
+	return strings.Contains("4381672943816729", s) || strings.Contains("9276183492761834", s)
+}

--- a/internal/Leetcode/840/840_test.go
+++ b/internal/Leetcode/840/840_test.go
@@ -1,0 +1,35 @@
+package _840
+
+import (
+	"testing"
+)
+
+func Test_numMagicSquaresInside(t *testing.T) {
+	type args struct {
+		grid [][]int
+	}
+	tests := []struct {
+		name string
+		args args
+		want int
+	}{
+		{
+			name: "Example 1",
+			args: args{
+				grid: [][]int{
+					{4, 3, 8, 4},
+					{9, 5, 1, 9},
+					{2, 7, 6, 2},
+				},
+			},
+			want: 1,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := numMagicSquaresInside(tt.args.grid); got != tt.want {
+				t.Errorf("numMagicSquaresInside() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
A 3 x 3 magic square is a 3 x 3 grid filled with distinct numbers from 1 to 9 such that each row, column, and both diagonals all have the same sum.

Given a row x col grid of integers, how many 3 x 3 contiguous magic square subgrids are there?

Note: while a magic square can only contain numbers from 1 to 9, grid may contain numbers up to 15.

Example 1:

Input: grid = [[4,3,8,4],[9,5,1,9],[2,7,6,2]]
Output: 1
Explanation:
The following subgrid is a 3 x 3 magic square:

while this one is not:

In total, there is only one magic square inside the given grid. Example 2:

Input: grid = [[8]]
Output: 0