### PR TITLE
feat(40): Medium

### DIFF
--- a/internal/Leetcode/40/40.go
+++ b/internal/Leetcode/40/40.go
@@ -1,0 +1,34 @@
+package _40
+
+import (
+	"sort"
+)
+
+func combinationSum2(candidates []int, target int) [][]int {
+	res := make([][]int, 0, 2^len(candidates))
+	//sort array
+	sort.Ints(candidates)
+	dfs([]int{}, 0, 0, target, candidates, &res)
+
+	return res
+}
+
+func dfs(cur []int, i, total, target int, candidates []int, res *[][]int) {
+	if total == target {
+		combination := make([]int, len(cur))
+		copy(combination, cur)
+		*res = append(*res, combination)
+		return
+	}
+	if total > target || i == len(candidates) {
+		return
+	}
+	cur = append(cur, candidates[i])
+	dfs(cur, i+1, total+candidates[i], target, candidates, res)
+	cur = cur[:len(cur)-1]
+
+	for i+1 < len(candidates) && candidates[i] == candidates[i+1] {
+		i++
+	}
+	dfs(cur, i+1, total, target, candidates, res)
+}

--- a/internal/Leetcode/40/40_test.go
+++ b/internal/Leetcode/40/40_test.go
@@ -1,0 +1,50 @@
+package _40
+
+import (
+	"reflect"
+	"testing"
+)
+
+func Test_combinationSum2(t *testing.T) {
+	type args struct {
+		candidates []int
+		target     int
+	}
+	tests := []struct {
+		name string
+		args args
+		want [][]int
+	}{
+		{
+			name: "Example 1",
+			args: args{
+				candidates: []int{10, 1, 2, 7, 6, 1, 5},
+				target:     8,
+			},
+			want: [][]int{
+				{1, 1, 6},
+				{1, 2, 5},
+				{1, 7},
+				{2, 6},
+			},
+		},
+		{
+			name: "Example 2",
+			args: args{
+				candidates: []int{2, 5, 2, 1, 2},
+				target:     5,
+			},
+			want: [][]int{
+				{1, 2, 2},
+				{5},
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := combinationSum2(tt.args.candidates, tt.args.target); !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("combinationSum2() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Given a collection of candidate numbers (candidates) and a target number (target), find all unique combinations in candidates where the candidate numbers sum to target.

Each number in candidates may only be used once in the combination.

Note: The solution set must not contain duplicate combinations.

Example 1:

Input: candidates = [10,1,2,7,6,1,5], target = 8
Output:
[
[1,1,6],
[1,2,5],
[1,7],
[2,6]
]
Example 2:

Input: candidates = [2,5,2,1,2], target = 5
Output:
[
[1,2,2],
[5]
]

Constraints:

1 <= candidates.length <= 100
1 <= candidates[i] <= 50
1 <= target <= 30