### PR TITLE
feat(264): Medium

### DIFF
--- a/internal/Leetcode/264/264.go
+++ b/internal/Leetcode/264/264.go
@@ -1,0 +1,29 @@
+package _264
+
+func GenerateUglyNumbers(n int) int {
+	uglyNumbers := make([]int, n)
+	uglyNumbers[0] = 1
+
+	i2, i3, i5 := 0, 0, 0
+	next2, next3, next5 := 2, 3, 5
+
+	for i := 1; i < n; i++ {
+		nextUgly := min(next2, next3, next5)
+		uglyNumbers[i] = nextUgly
+
+		if nextUgly == next2 {
+			i2++
+			next2 = uglyNumbers[i2] * 2
+		}
+		if nextUgly == next3 {
+			i3++
+			next3 = uglyNumbers[i3] * 3
+		}
+		if nextUgly == next5 {
+			i5++
+			next5 = uglyNumbers[i5] * 5
+		}
+	}
+
+	return uglyNumbers[n-1]
+}

--- a/internal/Leetcode/264/264_test.go
+++ b/internal/Leetcode/264/264_test.go
@@ -1,0 +1,34 @@
+package _264
+
+import (
+	"testing"
+)
+
+func TestGenerateUglyNumbers(t *testing.T) {
+	type args struct {
+		n int
+	}
+	tests := []struct {
+		name string
+		args args
+		want int
+	}{
+		{
+			name: "Example 1",
+			args: args{n: 10},
+			want: 12,
+		},
+		{
+			name: "Example 2",
+			args: args{n: 1},
+			want: 1,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := GenerateUglyNumbers(tt.args.n); got != tt.want {
+				t.Errorf("GenerateUglyNumbers() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
An ugly number is a positive integer whose prime factors are limited to 2, 3, and 5.

Given an integer n, return the nth ugly number.

Example 1:

Input: n = 10
Output: 12
Explanation: [1, 2, 3, 4, 5, 6, 8, 9, 10, 12] is the sequence of the first 10 ugly numbers. Example 2:

Input: n = 1
Output: 1
Explanation: 1 has no prime factors, therefore all of its prime factors are limited to 2, 3, and 5.

Constraints:

1 <= n <= 1690